### PR TITLE
34 add pooling functions with safeguard

### DIFF
--- a/reach/reach.py
+++ b/reach/reach.py
@@ -555,7 +555,7 @@ class Reach(object):
 
         """
         if isinstance(items, str):
-            raise ValueError("You passed a string, but we require an iterable")
+            items = [items]
         vectors = np.stack([self.norm_vectors[self.items[item]] for item in items])
         result = self._most_similar_batch(
             vectors, batch_size, num + 1, show_progressbar
@@ -602,8 +602,6 @@ class Reach(object):
 
         """
         if isinstance(items, str):
-            if items not in self.items:
-                raise KeyError(f"{items} is not in the set of items.")
             items = [items]
 
         vectors = np.stack([self.norm_vectors[self.items[x]] for x in items])
@@ -793,7 +791,7 @@ class Reach(object):
     def vector_similarity(self, vector: np.ndarray, items: Tokens) -> np.ndarray:
         """Compute the similarity between a vector and a set of items."""
         if isinstance(items, str):
-            raise ValueError("You passed a string, but we expect an iterable")
+            items = [items]
 
         items_vec = np.stack([self.norm_vectors[self.items[item]] for item in items])
         return self._sim(vector, items_vec)
@@ -822,9 +820,9 @@ class Reach(object):
 
         """
         if isinstance(items_1, str):
-            raise ValueError("You passed a string, but we expect an iterable")
+            items_1 = [items_1]
         if isinstance(items_2, str):
-            raise ValueError("You passed a string, but we expect an iterable")
+            items_2 = [items_2]
 
         items_1_matrix = np.stack(
             [self.norm_vectors[self.items[item]] for item in items_1]

--- a/reach/reach.py
+++ b/reach/reach.py
@@ -5,7 +5,17 @@ import json
 import logging
 from io import TextIOWrapper, open
 from pathlib import Path
-from typing import Any, Dict, Generator, Hashable, List, Optional, Tuple, Union
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    Hashable,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import numpy as np
 from tqdm import tqdm
@@ -16,7 +26,7 @@ PathLike = Union[str, Path]
 Matrix = Union[np.ndarray, List[np.ndarray]]
 SimilarityItem = List[Tuple[Hashable, float]]
 SimilarityResult = List[SimilarityItem]
-Tokens = List[Hashable]
+Tokens = Iterable[Hashable]
 
 
 logger = logging.getLogger(__name__)
@@ -102,8 +112,8 @@ class Reach(object):
         return self._indices
 
     @property
-    def sorted_items(self) -> List[Hashable]:
-        items: List[Hashable] = [
+    def sorted_items(self) -> Tokens:
+        items: Tokens = [
             item for item, _ in sorted(self.items.items(), key=lambda x: x[1])
         ]
         return items
@@ -209,8 +219,8 @@ class Reach(object):
                 desired_dtype,
                 **kwargs,
             )
-        except ValueError as e:
-            raise e
+        except ValueError as exc:
+            raise exc
         finally:
             if came_from_path:
                 file_handle.close()
@@ -371,6 +381,82 @@ class Reach(object):
         else:
             return self.vectors[index]
 
+    def mean_pool(
+        self, tokens: Tokens, remove_oov: bool = False, safeguard: bool = True
+    ) -> np.ndarray:
+        """
+        Mean pool a list of tokens.
+
+        Parameters
+        ----------
+        tokens : list.
+            The list of items to vectorize and then mean pool.
+        remove_oov : bool.
+            Whether to remove OOV items from the input.
+            If this is False, and an unknown item is encountered, then
+            the <UNK> symbol will be inserted if it is set. If it is not set,
+            then the function will throw a ValueError.
+        safeguard : bool.
+            There are a variety of reasons why we can't vectorize a list
+                of tokens:
+                - The list might be empty after removing OOV
+                - We remove OOV but haven't set <UNK>
+                - The list of tokens is empty
+            If safeguard is False, we simply supply a zero vector instead
+                of erroring out.
+
+        Returns
+        -------
+        vector: np.ndarray
+            a vector of the correct size, which is the mean of all tokens
+            in the sentence.
+
+        """
+        try:
+            return self.vectorize(tokens, remove_oov, False).mean(0)
+        except ValueError as exc:
+            if safeguard:
+                raise exc
+            return np.zeros(self.size)
+
+    def mean_pool_corpus(
+        self, corpus: List[Tokens], remove_oov: bool = False, safeguard: bool = True
+    ) -> np.ndarray:
+        """
+        Mean pool a list of list of tokens.
+
+        Parameters
+        ----------
+        corpus : a list of list of tokens.
+            The list of items to vectorize and then mean pool.
+        remove_oov : bool.
+            Whether to remove OOV items from the input.
+            If this is False, and an unknown item is encountered, then
+            the <UNK> symbol will be inserted if it is set. If it is not set,
+            then the function will throw a ValueError.
+        safeguard : bool.
+            There are a variety of reasons why we can't vectorize a list of tokens:
+                - The list might be empty after removing OOV
+                - We remove OOV but haven't set <UNK>
+                - The list of tokens is empty
+            If safeguard is False, we simply supply a zero vector instead of erroring.
+
+        Returns
+        -------
+        vector: np.ndarray
+            a matrix with number of rows n, where n is the number of input lists, and
+            columns s, which is the number of columns of a single vector.
+
+        """
+        out = []
+        for index, tokens in enumerate(corpus):
+            try:
+                out.append(self.mean_pool(tokens, remove_oov, safeguard))
+            except ValueError as exc:
+                raise ValueError(f"Tokens at {index} errored out") from exc
+
+        return np.stack(out)
+
     def bow(self, tokens: Tokens, remove_oov: bool = False) -> List[int]:
         """
         Create a bow representation of a list of tokens.
@@ -413,7 +499,7 @@ class Reach(object):
         return out
 
     def transform(
-        self, corpus: List[List[Hashable]], remove_oov: bool = False, norm: bool = False
+        self, corpus: List[Tokens], remove_oov: bool = False, norm: bool = False
     ) -> List[np.ndarray]:
         """
         Transform a corpus by repeated calls to vectorize, defined above.
@@ -469,10 +555,7 @@ class Reach(object):
 
         """
         if isinstance(items, str):
-            if items not in self.items:
-                raise KeyError(f"{items} is not in the set of items.")
-            items = [items]
-
+            raise ValueError("You passed a string, but we require an iterable")
         vectors = np.stack([self.norm_vectors[self.items[item]] for item in items])
         result = self._most_similar_batch(
             vectors, batch_size, num + 1, show_progressbar
@@ -710,7 +793,8 @@ class Reach(object):
     def vector_similarity(self, vector: np.ndarray, items: Tokens) -> np.ndarray:
         """Compute the similarity between a vector and a set of items."""
         if isinstance(items, str):
-            items = [items]
+            raise ValueError("You passed a string, but we expect an iterable")
+
         items_vec = np.stack([self.norm_vectors[self.items[item]] for item in items])
         return self._sim(vector, items_vec)
 
@@ -738,9 +822,10 @@ class Reach(object):
 
         """
         if isinstance(items_1, str):
-            items_1 = [items_1]
+            raise ValueError("You passed a string, but we expect an iterable")
         if isinstance(items_2, str):
-            items_2 = [items_2]
+            raise ValueError("You passed a string, but we expect an iterable")
+
         items_1_matrix = np.stack(
             [self.norm_vectors[self.items[item]] for item in items_1]
         )
@@ -749,7 +834,7 @@ class Reach(object):
         )
         return self._sim(items_1_matrix, items_2_matrix)
 
-    def intersect(self, itemlist: List[Hashable]) -> Reach:
+    def intersect(self, itemlist: Tokens) -> Reach:
         """
         Intersect a reach instance with a list of items.
 

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -1,5 +1,5 @@
-from typing import Tuple, List
 import unittest
+from typing import Hashable, List, Tuple
 
 import numpy as np
 
@@ -7,8 +7,8 @@ from reach import AutoReach, Reach
 
 
 class TestAuto(unittest.TestCase):
-    def data(self) -> Tuple[List[str], np.ndarray]:
-        words = [
+    def data(self) -> Tuple[List[Hashable], np.ndarray]:
+        words: List[Hashable] = [
             "donatello",
             "leonardo",
             "raphael",
@@ -72,7 +72,7 @@ class TestAuto(unittest.TestCase):
         instance = AutoReach(vectors, words, lowercase="auto")
         self.assertTrue(instance.lowercase)
 
-        words[0] = words[0].title()
+        words[0] = words[0].title()  # type: ignore
         instance = AutoReach(vectors, words, lowercase="auto")
         self.assertFalse(instance.lowercase)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,13 +1,14 @@
 import unittest
-from typing import Tuple, List
+from typing import Hashable, List, Tuple
 
 import numpy as np
+
 from reach import Reach
 
 
 class TestInit(unittest.TestCase):
-    def data(self) -> Tuple[List[str], np.ndarray]:
-        words = [
+    def data(self) -> Tuple[List[Hashable], np.ndarray]:
+        words: List[Hashable] = [
             "donatello",
             "leonardo",
             "raphael",
@@ -15,7 +16,8 @@ class TestInit(unittest.TestCase):
             "splinter",
             "hideout",
         ]
-        vectors = np.stack([np.arange(1, 7)] * 5).T
+        random_generator = np.random.RandomState(seed=44)
+        vectors = random_generator.standard_normal((6, 50))
 
         return words, vectors
 
@@ -24,7 +26,7 @@ class TestInit(unittest.TestCase):
         instance = Reach(vectors, words)
 
         self.assertEqual(len(instance), 6)
-        self.assertEqual(instance.size, 5)
+        self.assertEqual(instance.size, 50)
         self.assertTrue(np.allclose(instance.vectors, vectors))
 
         sorted_words, _ = zip(*sorted(instance.items.items(), key=lambda x: x[1]))

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,10 +1,10 @@
-from pathlib import Path
 import unittest
+from pathlib import Path
+from tempfile import NamedTemporaryFile
 
 import numpy as np
 
 from reach import Reach
-from tempfile import NamedTemporaryFile
 
 
 class TestLoad(unittest.TestCase):
@@ -189,7 +189,6 @@ class TestLoad(unittest.TestCase):
                 instance = Reach.load(tempfile.name, num_to_load=-1)
 
     def test_load_from_file_with_header(self) -> None:
-
         with NamedTemporaryFile(mode="w+") as tempfile:
             lines = self.lines()
             tempfile.write(lines)
@@ -229,7 +228,6 @@ class TestLoad(unittest.TestCase):
                 instance = Reach.load(tempfile.name, num_to_load=-1)
 
     def test_save_load_fast_format(self) -> None:
-
         with NamedTemporaryFile("w+") as tempfile:
             lines = self.lines()
             tempfile.write(lines)
@@ -246,7 +244,6 @@ class TestLoad(unittest.TestCase):
             self.assertEqual(instance.name, instance_2.name)
 
     def test_save_load(self) -> None:
-
         with NamedTemporaryFile("w+") as tempfile:
             lines = self.lines()
             tempfile.write(lines)

--- a/tests/test_vectorize.py
+++ b/tests/test_vectorize.py
@@ -1,0 +1,151 @@
+import logging
+import unittest
+from typing import Hashable, List, Tuple
+
+import numpy as np
+
+from reach import Reach
+
+logger = logging.getLogger(__name__)
+
+
+class TestVectorize(unittest.TestCase):
+    def data(self) -> Tuple[List[Hashable], np.ndarray]:
+        words: List[Hashable] = [
+            "donatello",
+            "leonardo",
+            "raphael",
+            "michelangelo",
+            "splinter",
+            "hideout",
+        ]
+        random_generator = np.random.RandomState(seed=44)
+        vectors = random_generator.standard_normal((6, 50))
+
+        return words, vectors
+
+    def test_vectorize_no_unk(self) -> None:
+        words, vectors = self.data()
+        reach = Reach(vectors, words)
+
+        with self.assertRaises(ValueError):
+            reach.vectorize(("donatello", "abcd"), remove_oov=False)
+
+        with self.assertRaises(ValueError):
+            reach.vectorize([])
+
+        with self.assertRaises(ValueError):
+            reach.vectorize("")
+
+        vec = reach.vectorize(("donatello", "abcd"), remove_oov=True)
+        self.assertEqual(len(vec), 1)
+        self.assertTrue(np.allclose(vec, reach["donatello"]))
+
+    def test_vectorize_unk(self) -> None:
+        words, vectors = self.data()
+        words.append("<UNK>")
+        vectors = np.concatenate([vectors, np.zeros((1, vectors.shape[1]))])
+        reach = Reach(vectors, words, unk_index=len(words) - 1)
+
+        self.assertEqual(reach.indices[reach.unk_index], "<UNK>")  # type: ignore
+        self.assertTrue(np.allclose(vectors[-1], np.zeros(reach.size)))
+
+    def test_bow_no_unk(self) -> None:
+        words, vectors = self.data()
+        reach = Reach(vectors, words)
+
+        bow = reach.bow(["donatello", "leonardo", "michelangelo"])
+        self.assertEqual(bow, [0, 1, 3])
+
+        bow = reach.bow(["donatello", "leonardo", "rgieurghegh"], remove_oov=True)
+        self.assertEqual(bow, [0, 1])
+
+        with self.assertRaises(ValueError):
+            bow = reach.bow(["donatello", "wroughwuorg"], remove_oov=False)
+
+        with self.assertRaises(ValueError):
+            bow = reach.bow("")
+
+    def test_bow_unk(self) -> None:
+        words, vectors = self.data()
+        words.append("<UNK>")
+        vectors = np.concatenate([vectors, np.zeros((1, vectors.shape[1]))])
+        reach = Reach(vectors, words, unk_index=len(words) - 1)
+
+        bow = reach.bow(["donatello", "leonardo", "rgieurghegh"])
+        self.assertEqual(bow, [0, 1, reach.unk_index])
+
+        bow = reach.bow(["donatello", "leonardo", "rgieurghegh"], remove_oov=True)
+        self.assertEqual(bow, [0, 1])
+
+    def test_transform(self) -> None:
+        words, vectors = self.data()
+        reach = Reach(vectors, words)
+
+        with self.assertRaises(ValueError):
+            reach.transform([["donatello", "raphael"], ["dog"], ["clown", "donatello"]])
+
+        matrices = reach.transform(
+            [["donatello", "raphael"], ["donatello", "splinter"]]
+        )
+
+        expected = [
+            np.stack([reach["donatello"], reach["raphael"]]),
+            np.stack([reach["donatello"], reach["splinter"]]),
+        ]
+        for matrix, exp_matrix in zip(matrices, expected):
+            self.assertTrue(np.allclose(matrix, exp_matrix))
+
+        matrices = reach.transform(
+            [["donatello", "raphael"], ["rqghqgr", "splinter"]], remove_oov=True
+        )
+
+        expected = [
+            np.stack([reach["donatello"], reach["raphael"]]),
+            np.stack([reach["splinter"]]),
+        ]
+        for matrix, exp_matrix in zip(matrices, expected):
+            self.assertTrue(np.allclose(matrix, exp_matrix))
+
+        with self.assertRaises(ValueError):
+            reach.transform([[]])
+
+        empty_result = reach.transform([])
+        self.assertEqual(empty_result, [])
+
+    def test_mean_pool(self) -> None:
+        words, vectors = self.data()
+        reach = Reach(vectors, words)
+
+        with self.assertRaises(ValueError):
+            reach.mean_pool(["donatello", "dog"])
+
+        vec = reach.mean_pool(["donatello", "dog"], safeguard=False)
+        self.assertTrue(np.allclose(vec, np.zeros_like(vec)))
+
+        vec = reach.mean_pool(["donatello", "dog"], remove_oov=True)
+        self.assertTrue(np.allclose(vec, reach["donatello"]))
+
+    def test_mean_pool_unk(self) -> None:
+        words, vectors = self.data()
+        words.append("<UNK>")
+        vectors = np.concatenate([vectors, np.zeros((1, vectors.shape[1]))])
+        reach = Reach(vectors, words, unk_index=len(words) - 1)
+
+        vec = reach.mean_pool(["donatello", "dog"])
+        self.assertTrue(np.allclose(vec, reach["donatello"] / 2))
+
+        vec = reach.mean_pool(["donatello", "dog"], safeguard=True)
+        self.assertTrue(np.allclose(vec, reach["donatello"] / 2))
+
+        vec = reach.mean_pool(["donatello", "dog"], remove_oov=True)
+        self.assertTrue(np.allclose(vec, reach["donatello"]))
+
+        vec = reach.mean_pool([], safeguard=False)
+        self.assertTrue(np.allclose(vec, np.zeros_like(vec)))
+
+        with self.assertRaises(ValueError):
+            reach.mean_pool_corpus([[], ["dog"], ["guogrwohu"]], safeguard=True)
+
+        matrix = reach.mean_pool_corpus([[], ["dog"], ["guogrwohu"]], safeguard=False)
+        self.assertTrue(np.allclose(matrix, np.zeros_like(matrix)))


### PR DESCRIPTION
This PR adds pooling functions, e.g., functions that create a single vector out of a list of tokens. We currently only support mean tokens. The main reason for adding this PR is that I see that people using reach are struggling with OOV tokens. Additionally, I keep having to write the same boiler plate code over and over again, in order to catch errors.