### PR TITLE
feat: Add indices_threshold function

### DIFF
--- a/reach/reach.py
+++ b/reach/reach.py
@@ -628,6 +628,48 @@ class Reach:
                 word_index = np.flip(np.argsort(sims_for_word))
                 yield [(self.indices[indices[idx]], sims_for_word[idx]) for idx in word_index]
 
+    def indices_threshold(
+        self,
+        vectors: npt.NDArray,
+        threshold: float = 0.5,
+        batch_size: int = 100,
+        show_progressbar: bool = False,
+    ) -> Iterator[np.ndarray]:
+        """
+        Retrieve the unsorted indices of the nearest neighbors for the given vectors above a threshold.
+
+        This method is useful if you want to find the indices of the most similar items above a certain threshold
+        but don't need them to be sorted, which is a time consuming operation.
+
+        :param vectors: The vectors to find the most similar vectors to.
+        :param threshold: The threshold to use.
+        :param batch_size: The batch size to use. 100 is a good default option. Increasing the batch size may increase
+            the speed.
+        :param show_progressbar: Whether to show a progressbar.
+
+        :return: For each item in the input, the indices of the nearest neighbors are returned as an array.
+        """
+        vectors = np.array(vectors)
+        if np.ndim(vectors) == 1:
+            vectors = vectors[None, :]
+
+        return self._indices_threshold_batch(vectors, batch_size, threshold, show_progressbar)
+
+    def _indices_threshold_batch(
+        self,
+        vectors: np.ndarray,
+        batch_size: int,
+        threshold: float,
+        show_progressbar: bool,
+    ) -> Iterator[np.ndarray]:
+        """Batched cosine similarity. Returns the indices of vectors above the threshold."""
+        for i in tqdm(range(0, len(vectors), batch_size), disable=not show_progressbar):
+            batch = vectors[i : i + batch_size]
+            similarities = self._sim(batch, self.norm_vectors)
+            for _, sims in enumerate(similarities):
+                # Yield indices of neighbors with similarity above the threshold
+                yield np.flatnonzero(sims > threshold)
+
     @staticmethod
     def normalize(vectors: npt.NDArray, norms: npt.NDArray | None = None) -> npt.NDArray:
         """

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -194,3 +194,30 @@ class TestSimilarity(unittest.TestCase):
         result2 = instance.vector_similarity(vectors[0], [words[1]])
 
         self.assertEqual(result, result2)
+
+    def test_indices_threshold(self) -> None:
+        """Test the indices_threshold function."""
+        words, vectors = self.data()
+        instance = Reach(vectors, words)
+
+        # Set a high threshold to test that no indices are returned
+        threshold = 0.99
+        for word, vector in zip(words, vectors):
+            indices = list(instance.indices_threshold(np.array([vector]), threshold=threshold))[0]
+            # Exclude self-similarity
+            indices = indices[indices != instance.items[word]]
+            self.assertEqual(indices.size, 0)
+
+        # Set a low threshold to ensure some indices are returned
+        threshold = 0.0
+        for word, vector in zip(words, vectors):
+            indices = list(instance.indices_threshold(np.array([vector]), threshold=threshold))[0]
+
+            # Get the actual sorted indices
+            similarities = instance.norm_vectors @ vector
+            expected_indices = np.flatnonzero(similarities > threshold)
+            indices_sorted = np.sort(indices)
+            expected_indices_sorted = np.sort(expected_indices)
+
+            # Assert that the filtered and sorted indices match
+            self.assertTrue(np.array_equal(indices_sorted, expected_indices_sorted))

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -195,15 +195,15 @@ class TestSimilarity(unittest.TestCase):
 
         self.assertEqual(result, result2)
 
-    def test_indices_threshold(self) -> None:
-        """Test the indices_threshold function."""
+    def test_nearest_neighbor_indices(self) -> None:
+        """Test the nearest_neighbor_indices function."""
         words, vectors = self.data()
         instance = Reach(vectors, words)
 
         # Set a high threshold to test that no indices are returned
         threshold = 0.99
         for word, vector in zip(words, vectors):
-            indices = list(instance.indices_threshold(np.array([vector]), threshold=threshold))[0]
+            indices = list(instance.nearest_neighbor_indices(np.array([vector]), threshold=threshold))[0]
             # Exclude self-similarity
             indices = indices[indices != instance.items[word]]
             self.assertEqual(indices.size, 0)
@@ -211,13 +211,15 @@ class TestSimilarity(unittest.TestCase):
         # Set a low threshold to ensure some indices are returned
         threshold = 0.0
         for word, vector in zip(words, vectors):
-            indices = list(instance.indices_threshold(np.array([vector]), threshold=threshold))[0]
+            indices = list(instance.nearest_neighbor_indices(np.array([vector]), threshold=threshold))[0]
 
-            # Get the actual sorted indices
+            # Get the actual indices
             similarities = instance.norm_vectors @ vector
             expected_indices = np.flatnonzero(similarities > threshold)
-            indices_sorted = np.sort(indices)
-            expected_indices_sorted = np.sort(expected_indices)
 
-            # Assert that the filtered and sorted indices match
-            self.assertTrue(np.array_equal(indices_sorted, expected_indices_sorted))
+            # Convert both to sets for comparison
+            indices_set = set(indices)
+            expected_indices_set = set(expected_indices)
+
+            # Assert that the filtered indices match the expected indices
+            self.assertEqual(indices_set, expected_indices_set)


### PR DESCRIPTION
This PR adds an indices_threshold function that returns unsorted indices above a threshold, a faster alternative to nearest_neighbors_threshold if you don't need sorted results.